### PR TITLE
#21: Remove dependence from slf4j-nop (closes #21)

### DIFF
--- a/backend/project/Dependencies.scala
+++ b/backend/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val slickVersion = "3.2.1"
   lazy val slick = Seq(
     "com.typesafe.slick" %% "slick" % slickVersion,
-    "org.slf4j" % "slf4j-nop" % "1.6.4",
+    "org.slf4j" % "slf4j-nop" % "1.6.4" % "test",
     "com.typesafe.slick" %% "slick-hikaricp" % slickVersion
   )
   lazy val postgresql = Seq("org.postgresql" % "postgresql" % "9.4.1212")


### PR DESCRIPTION
Closes #21

Changed to `"org.slf4j" % "slf4j-nop" % "1.6.4" % "test"` so that the dependency is used only for testing. This avoids annoying warnings such as:

![image](https://user-images.githubusercontent.com/2476080/35109790-a5b2951e-fc77-11e7-972f-a3f693439287.png)

## Test Plan

### tests performed
- compiles
- tried to run test with no proper database configured
