### PR TITLE
Adding ts declarations to release (closes #29)

### DIFF
--- a/web/.babelrc
+++ b/web/.babelrc
@@ -1,7 +1,5 @@
 {
   "presets": [
-    ["buildo", {
-      "modules": false
-    }]
+    ["buildo", {}]
   ]
 }

--- a/web/.babelrc
+++ b/web/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["buildo", {
+      "modules": false
+    }]
+  ]
+}

--- a/web/metarpheus-config.js
+++ b/web/metarpheus-config.js
@@ -1,20 +1,10 @@
 const path = require('path');
 const cwd = process.cwd();
-const modelPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
-/* eslint-disable */
-import * as t from 'tcomb';
-`;
-const apiPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
-/* eslint-disable */
-import * as t from 'tcomb';
-import * as m from './model'
-`;
 
 module.exports = {
-  modelPrelude,
-  apiPrelude,
   apiPaths: [
-    '../backend/src/main/scala'
+    '../backend/wiro/src/main/scala',
+    '../backend/core/src/main/scala'
   ].map(p => path.resolve(cwd, p)),
   overrides: {
     Instant: () => 't.Date',

--- a/web/metarpheus-ts-config.js
+++ b/web/metarpheus-ts-config.js
@@ -1,7 +1,16 @@
 const path = require('path');
 const cwd = process.cwd();
 
+const modelPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
+import * as t from 'io-ts';
+
+export interface Unit {};
+export const Unit = t.interface({}, 'Unit');
+
+`;
+
 module.exports = {
+  modelPrelude,
   apiPaths: [
     '../backend/wiro/src/main/scala',
     '../backend/core/src/main/scala'

--- a/web/metarpheus-ts-config.js
+++ b/web/metarpheus-ts-config.js
@@ -1,14 +1,12 @@
 const path = require('path');
 const cwd = process.cwd();
-const modelPrelude = `/* tslint:disable */
-`;
 
 module.exports = {
   apiPaths: [
-    '../backend/src/main/scala'
+    '../backend/wiro/src/main/scala',
+    '../backend/core/src/main/scala'
   ].map(p => path.resolve(__dirname, p)),
   modelOut: path.resolve(cwd, 'src/metarpheus/model-ts.ts'),
   apiOut: path.resolve(cwd, 'src/metarpheus/api-ts.ts'),
-  modelPrelude,
   wiro: true
 };

--- a/web/metarpheus-ts-config.js
+++ b/web/metarpheus-ts-config.js
@@ -5,7 +5,7 @@ const modelPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts';
 
 export interface Unit {};
-export const Unit = t.interface({}, 'Unit');
+export const Unit = t.strict({}, 'Unit');
 
 `;
 

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "test-watch": "jest --watch",
-    "build": "rm -rf lib && mkdir lib && tsc",
+    "build": "rm -rf lib && mkdir lib && tsc && npx babel src --out-dir lib",
     "lint": "scriptoni lint src test",
     "lint-fix": "scriptoni lint --fix src test",
     "preversion": "npm run lint && npm run test",

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "description": "A library that handles authentication with toctoc in a React webapp using buildo stack",
   "main": "lib",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "test": "jest",
     "test-watch": "jest --watch",

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest",
     "test-watch": "jest --watch",
-    "build": "rm -rf lib && mkdir lib && tsc && npx babel src --out-dir lib",
+    "build": "rm -rf lib && mkdir lib && tsc && babel src --out-dir lib",
     "lint": "scriptoni lint src test",
     "lint-fix": "scriptoni lint --fix src test",
     "preversion": "npm run lint && npm run test",
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@types/jest": "^21.1.2",
+    "babel-cli": "^6.26.0",
     "jest": "^21.2.1",
     "jest-localstorage-mock": "^2.0.1",
     "scriptoni": "^0.10.0",

--- a/web/package.json
+++ b/web/package.json
@@ -51,13 +51,14 @@
     ]
   },
   "dependencies": {
+    "axios": "^0.17.1",
     "cookies-js": "^1.2.3"
   },
   "devDependencies": {
     "@types/jest": "^21.1.2",
     "jest": "^21.2.1",
     "jest-localstorage-mock": "^2.0.1",
-    "scriptoni": "^0.7.6",
+    "scriptoni": "^0.10.0",
     "smooth-release": "^8.0.4",
     "ts-jest": "^21.1.2",
     "tslint": "^5.7.0",

--- a/web/package.json
+++ b/web/package.json
@@ -59,7 +59,7 @@
     "@types/jest": "^21.1.2",
     "jest": "^21.2.1",
     "jest-localstorage-mock": "^2.0.1",
-    "scriptoni": "^0.10.0",
+    "scriptoni": "^0.10.1",
     "smooth-release": "^8.0.4",
     "ts-jest": "^21.1.2",
     "tslint": "^5.7.0",

--- a/web/package.json
+++ b/web/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@types/jest": "^21.1.2",
-    "babel-cli": "^6.26.0",
     "jest": "^21.2.1",
     "jest-localstorage-mock": "^2.0.1",
     "scriptoni": "^0.10.0",

--- a/web/src/SessionSerializer/SessionSerializer.ts
+++ b/web/src/SessionSerializer/SessionSerializer.ts
@@ -1,7 +1,7 @@
 import { TocTocToken } from '../metarpheus/model-ts'
 
-type SessionSetter = (key: string, stringifiedValue: string) => void
-type SessionGetter = (key: string) => string | null
+export type SessionSetter = (key: string, stringifiedValue: string) => void
+export type SessionGetter = (key: string) => string | null
 
 const serializationKey = 'AUTH_TOKEN'
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -1,0 +1,1 @@
+export { API } from './metarpheus/api';

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -1,1 +1,2 @@
-export { API } from './metarpheus/api';
+import API from './metarpheus/api';
+export { API };

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,2 +1,0 @@
-import API from './metarpheus/api'
-export { API }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,4 +1,8 @@
-export { Model, TSModel } from './model'
-export { API } from './api'
+import TSAPI from './metarpheus/api-ts'
+import * as TSModel from './metarpheus/model-ts'
+
+export { TSAPI, TSModel }
+
+
 
 export * from './SessionSerializer'

--- a/web/src/metarpheus/api-ts.ts
+++ b/web/src/metarpheus/api-ts.ts
@@ -1,0 +1,84 @@
+
+
+// DO NOT EDIT MANUALLY - metarpheus-generated
+import axios, { AxiosError } from 'axios'
+import * as t from 'io-ts'
+import * as m from './model-ts'
+
+interface RouteConfig {
+  apiEndpoint: string,
+  timeout: number,
+  unwrapApiResponse: (resp: any) => any
+}
+
+import { failure } from 'io-ts/lib/PathReporter'
+export function unsafeValidate<S, A>(value: any, type: t.Type<S, A>): A {
+  return t.validate(value, type).fold(errors => {
+    throw new Error(failure(errors).join('\n'))
+  }, t.identity)
+}
+
+const parseError = (err: AxiosError) => {
+  try {
+    const { errors = [] } = err.response!.data;
+    return Promise.reject({ status: err.response!.status, errors });
+  } catch (e) {
+    return Promise.reject({ status: err && err.response && err.response.status || 0, errors: [] });
+  }
+};
+
+export default function getRoutes(config: RouteConfig) {
+  return {
+    tokenAuthenticationController_login: function ({ login }: { login: m.Login }): Promise<m.TocTocToken> {
+      return axios({
+        method: 'post',
+        url: `${config.apiEndpoint}/toctoc/login`,
+        params: {
+
+        },
+        data: {
+          login
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        timeout: config.timeout
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.TocTocToken), parseError) as any
+    },
+
+    tokenAuthenticationController_refresh: function ({ refreshToken }: { refreshToken: m.RefreshToken }): Promise<m.TocTocToken> {
+      return axios({
+        method: 'post',
+        url: `${config.apiEndpoint}/toctoc/refresh`,
+        params: {
+
+        },
+        data: {
+          refreshToken
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        timeout: config.timeout
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.TocTocToken), parseError) as any
+    },
+
+    tokenAuthenticationController_logout: function ({ token }: { token: string }): Promise<m.Unit> {
+      return axios({
+        method: 'post',
+        url: `${config.apiEndpoint}/toctoc/logout`,
+        params: {
+
+        },
+        data: {
+
+        },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Token token="${token}"`
+        },
+        timeout: config.timeout
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.Unit), parseError) as any
+    }
+  }
+}

--- a/web/src/metarpheus/api-ts.ts
+++ b/web/src/metarpheus/api-ts.ts
@@ -5,7 +5,7 @@ import axios, { AxiosError } from 'axios'
 import * as t from 'io-ts'
 import * as m from './model-ts'
 
-interface RouteConfig {
+export interface RouteConfig {
   apiEndpoint: string,
   timeout: number,
   unwrapApiResponse: (resp: any) => any

--- a/web/src/metarpheus/api.js
+++ b/web/src/metarpheus/api.js
@@ -1,8 +1,9 @@
 
 // DO NOT EDIT MANUALLY - metarpheus-generated
 /* eslint-disable */
-import * as t from 'tcomb';
-import * as m from './model'
+import t from 'tcomb';
+
+import * as m from './model';
 
 
 export default [

--- a/web/src/metarpheus/model-ts.ts
+++ b/web/src/metarpheus/model-ts.ts
@@ -2,7 +2,7 @@
 import * as t from 'io-ts';
 
 export interface Unit {};
-export const Unit = t.interface({}, 'Unit');
+export const Unit = t.strict({}, 'Unit');
 
 export interface AccessToken {
   value: string,

--- a/web/src/metarpheus/model-ts.ts
+++ b/web/src/metarpheus/model-ts.ts
@@ -1,23 +1,42 @@
-
-/* tslint:disable */
-
+// DO NOT EDIT MANUALLY - metarpheus-generated
+import * as t from 'io-ts'
 
 export interface AccessToken {
   value: string,
   expiresAt: string
 }
 
+export const AccessToken = t.interface({
+  value: t.string,
+  expiresAt: t.string
+}, 'AccessToken')
+
 export interface Login {
   username: string,
   password: string
 }
+
+export const Login = t.interface({
+  username: t.string,
+  password: t.string
+}, 'Login')
 
 export interface RefreshToken {
   value: string,
   expiresAt: string
 }
 
+export const RefreshToken = t.interface({
+  value: t.string,
+  expiresAt: t.string
+}, 'RefreshToken')
+
 export interface TocTocToken {
   accessToken: AccessToken,
   refreshToken: RefreshToken
 }
+
+export const TocTocToken = t.interface({
+  accessToken: AccessToken,
+  refreshToken: RefreshToken
+}, 'TocTocToken')

--- a/web/src/metarpheus/model-ts.ts
+++ b/web/src/metarpheus/model-ts.ts
@@ -1,5 +1,8 @@
 // DO NOT EDIT MANUALLY - metarpheus-generated
-import * as t from 'io-ts'
+import * as t from 'io-ts';
+
+export interface Unit {};
+export const Unit = t.interface({}, 'Unit');
 
 export interface AccessToken {
   value: string,

--- a/web/src/metarpheus/model.js
+++ b/web/src/metarpheus/model.js
@@ -1,7 +1,7 @@
 
 // DO NOT EDIT MANUALLY - metarpheus-generated
 /* eslint-disable */
-import * as t from 'tcomb';
+import t from 'tcomb';
 
 
 export const AccessToken = t.declare('AccessToken');

--- a/web/src/model.js
+++ b/web/src/model.js
@@ -1,1 +1,2 @@
-export { Model } from './metarpheus/model';
+import * as Model from './metarpheus/model';
+export { Model };

--- a/web/src/model.js
+++ b/web/src/model.js
@@ -1,0 +1,1 @@
+export { Model } from './metarpheus/model';

--- a/web/src/model.ts
+++ b/web/src/model.ts
@@ -1,5 +1,0 @@
-import * as Model from './metarpheus/model'
-import * as TSModel from './metarpheus/model-ts'
-
-export { Model }
-export { TSModel }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -15,7 +15,6 @@
     "target": "es5",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
-    "declaration": true,
     "lib": [
       "es6",
       "dom"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -10,16 +10,22 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noEmitOnError": false,
-    "allowJs": true,
     "strictNullChecks": true,
     "target": "es5",
     "moduleResolution": "node",
+    "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "lib": [
       "es6",
       "dom"
     ]
   },
+  "exclude": [
+    "./src/api.js",
+    "./src/model.js",
+    "./src/metarpheus/api.js",
+    "./src/metarpheus/model.js"
+  ],
   "include": [
     "./src/*",
     "typings"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -15,6 +15,7 @@
     "target": "es5",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
+    "declaration": true,
     "lib": [
       "es6",
       "dom"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -21,10 +21,7 @@
     ]
   },
   "exclude": [
-    "./src/api.js",
-    "./src/model.js",
-    "./src/metarpheus/api.js",
-    "./src/metarpheus/model.js"
+    "./src/**/*.js"
   ],
   "include": [
     "./src/*",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -348,7 +348,7 @@ axios@^0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-babel-cli@^6.16.0:
+babel-cli@^6.16.0, babel-cli@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
   dependencies:

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -182,9 +182,17 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-differ@^1.0.0:
   version "1.0.0"
@@ -227,6 +235,10 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
 array.prototype.find@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
@@ -264,6 +276,10 @@ assert@^1.1.1, assert@^1.3.0:
   dependencies:
     util "0.10.3"
 
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -294,6 +310,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+atob@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
+
 atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
@@ -320,6 +340,13 @@ aws-sign2@~0.7.0:
 aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+axios@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
+  dependencies:
+    follow-redirects "^1.2.5"
+    is-buffer "^1.1.5"
 
 babel-cli@^6.16.0:
   version "6.26.0"
@@ -1001,6 +1028,18 @@ base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
 
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -1115,6 +1154,22 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+braces@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.0.tgz#a46941cb5fb492156b3d6a656e06c35364e3e66e"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -1225,6 +1280,20 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1319,6 +1388,14 @@ chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
 chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1354,6 +1431,15 @@ clap@^1.0.9:
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
   dependencies:
     chalk "^1.1.3"
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 clean-css@4.1.x:
   version "4.1.9"
@@ -1446,6 +1532,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
@@ -1522,6 +1615,10 @@ commander@2.11.x, commander@^2.11.0, commander@^2.8.1, commander@^2.9.0, command
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
 compressible@~2.0.11:
   version "2.0.11"
@@ -1622,6 +1719,10 @@ cookie@0.3.1:
 cookies-js@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/cookies-js/-/cookies-js-1.2.3.tgz#03315049e7c52bee3f73186a69167eab0ddb2d31"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
@@ -1892,15 +1993,25 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
 deep-equal@^1.0.1:
   version "1.0.1"
@@ -1932,6 +2043,18 @@ define-properties@^1.1.2:
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
 
 defined@^1.0.0:
   version "1.0.0"
@@ -2494,6 +2617,18 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -2546,6 +2681,19 @@ express@^4.13.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -2555,6 +2703,19 @@ extglob@^0.3.1:
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
+
+extglob@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 extract-text-webpack-plugin@^3.0.0-rc.1:
   version "3.0.1"
@@ -2640,6 +2801,15 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 finalhandler@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
@@ -2694,11 +2864,17 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+follow-redirects@^1.2.5:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
+  dependencies:
+    debug "^3.1.0"
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -2742,9 +2918,15 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
-fp-ts@^0.3.0:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-0.3.5.tgz#eb00258e0c2643ae370a4588b12e7b71dee985bc"
+fp-ts@^0.6.4:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-0.6.8.tgz#3b4ac3251f3565b2aefceffd787eb06c30c04b52"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -2842,6 +3024,10 @@ get-stdin@^5.0.0:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -2994,9 +3180,40 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 has@^1.0.1:
   version "1.0.1"
@@ -3312,21 +3529,15 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-io-ts-codegen@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/io-ts-codegen/-/io-ts-codegen-0.0.1.tgz#40f1d00b8bde1dd0672fed3099bd2192db2e6f79"
-  dependencies:
-    io-ts "^0.5.0"
+io-ts-codegen@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/io-ts-codegen/-/io-ts-codegen-0.1.2.tgz#d0b5581b475604bd5538839651639598013f765d"
 
-io-ts-codegen@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/io-ts-codegen/-/io-ts-codegen-0.0.3.tgz#5f7e5cadb98ee3b95a148c282d3493766e54ce9e"
-
-io-ts@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-0.5.1.tgz#7cf08ce8ee751bf8b64899fd7dc3eb6fb9f31243"
+io-ts@^0.9.2:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-0.9.8.tgz#3a904d326a0ced92364e853c9bdd788d9ab1554d"
   dependencies:
-    fp-ts "^0.3.0"
+    fp-ts "^0.6.4"
 
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
@@ -3343,6 +3554,18 @@ irregular-plurals@^1.0.0:
 is-absolute-url@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
+
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -3374,9 +3597,37 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.0.0"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
 is-directory@^0.3.1:
   version "0.3.1"
@@ -3392,9 +3643,15 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
@@ -3468,6 +3725,12 @@ is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
+is-odd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-1.0.0.tgz#3b8a932eb028b3775c39bb09e91767accdb69088"
+  dependencies:
+    is-number "^3.0.0"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -3488,7 +3751,7 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.1:
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -3582,7 +3845,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isobject@^3.0.1:
+isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
@@ -4016,7 +4279,7 @@ kind-of@^2.0.1:
   dependencies:
     is-buffer "^1.0.2"
 
-kind-of@^3.0.2, kind-of@^3.2.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -4027,6 +4290,14 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+kind-of@^5.0.0, kind-of@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
 known-css-properties@^0.2.0:
   version "0.2.0"
@@ -4045,6 +4316,12 @@ lazy-cache@^0.2.3:
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lazy-cache@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
+  dependencies:
+    set-getter "^0.1.0"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -4307,9 +4584,19 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -4379,12 +4666,12 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-metarpheus-io-ts@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/metarpheus-io-ts/-/metarpheus-io-ts-0.1.5.tgz#0ec3929b4ab9218bc06b0928804775b6dad06286"
+metarpheus-io-ts@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/metarpheus-io-ts/-/metarpheus-io-ts-0.1.13.tgz#4a2ab1378e40530b69e166ac710950e737d14b24"
   dependencies:
     commander "^2.9.0"
-    io-ts-codegen "0.0.3"
+    io-ts-codegen "^0.1.1"
     lodash "^4.17.4"
 
 metarpheus-tcomb@^0.2:
@@ -4422,6 +4709,24 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     object.omit "^2.0.0"
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
+
+micromatch@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.0"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    extglob "^2.0.2"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.0"
+    nanomatch "^1.2.5"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -4474,6 +4779,13 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
 mixin-object@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
@@ -4518,6 +4830,22 @@ mute-stream@0.0.5:
 nan@^2.0.0, nan@^2.3.0, nan@^2.3.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
+nanomatch@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.7.tgz#53cd4aa109ff68b7f869591fdc9d10daeeea3e79"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    is-odd "^1.0.0"
+    kind-of "^5.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4746,6 +5074,14 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
 object-hash@^1.1.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.2.0.tgz#e96af0e96981996a1d47f88ead8f74f1ebc4422b"
@@ -4757,6 +5093,12 @@ object-keys@^1.0.10, object-keys@^1.0.8:
 object-path@^0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.9.2.tgz#0fd9a74fc5fad1ae3968b586bda5c632bd6c05a5"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
 
 object.assign@^4.0.1, object.assign@^4.0.4:
   version "4.0.4"
@@ -4772,6 +5114,12 @@ object.omit@^2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
 
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.1"
@@ -4957,6 +5305,10 @@ parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -5077,6 +5429,10 @@ portfinder@^1.0.9:
     async "^1.5.2"
     debug "^2.2.0"
     mkdirp "0.5.x"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
 postcss-calc@^5.2.0:
   version "5.3.1"
@@ -5666,6 +6022,12 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
+regex-not@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.0.tgz#42f83e39771622df826b02af176525d6a5f157f9"
+  dependencies:
+    extend-shallow "^2.0.1"
+
 regex-parser@^2.2.1:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.8.tgz#da4c0cda5a828559094168930f455f532b6ffbac"
@@ -5731,7 +6093,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -5855,7 +6217,7 @@ resolve-url-loader@^2.1.0:
     source-map "^0.5.6"
     urix "^0.1.0"
 
-resolve-url@~0.2.1:
+resolve-url@^0.2.1, resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
@@ -5971,9 +6333,9 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-scriptoni@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/scriptoni/-/scriptoni-0.7.6.tgz#e9cc5450208863f7ec17b100debc857a33e54f7a"
+scriptoni@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/scriptoni/-/scriptoni-0.10.0.tgz#aa1eb3b5ad075ebf99d4ea952d98df3a3ed2ad82"
   dependencies:
     babel-cli "^6.16.0"
     babel-core "^6.24.1"
@@ -5992,10 +6354,9 @@ scriptoni@^0.7.6:
     extract-text-webpack-plugin "^3.0.0-rc.1"
     file-loader "^0.11.2"
     html-webpack-plugin "^2.29.0"
-    io-ts "^0.5.0"
-    io-ts-codegen "0.0.1"
+    io-ts "^0.9.2"
     metarpheus "0.1.7"
-    metarpheus-io-ts "^0.1.5"
+    metarpheus-io-ts "^0.1.12"
     metarpheus-tcomb "^0.2"
     minimist "^1.2.0"
     node-glob "^1.2.0"
@@ -6015,8 +6376,8 @@ scriptoni@^0.7.6:
     stylelint-config-buildo "github:buildo/stylelint-config"
     stylelint-webpack-plugin "^0.8.0"
     svg-react-loader "^0.4.4"
-    ts-loader "^2.2.2"
-    typescript "^2.4.1"
+    ts-loader "^3.2.0"
+    typescript "^2.6.2"
     virtual-module-webpack-plugin "^0.3.0"
     webpack "^3.1.0"
     webpack-dev-server "^2.5.1"
@@ -6096,9 +6457,33 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
+  dependencies:
+    to-object-path "^0.3.0"
+
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 setimmediate@^1.0.4:
   version "1.0.5"
@@ -6199,6 +6584,33 @@ smooth-release@^8.0.4:
     tcomb "^3.2.15"
     update-notifier "^2.1.0"
 
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.1.tgz#e12b5487faded3e3dea0ac91e9400bf75b401370"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^2.0.0"
+
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
@@ -6252,6 +6664,16 @@ source-map-resolve@^0.3.0:
     source-map-url "~0.3.0"
     urix "~0.1.0"
 
+source-map-resolve@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  dependencies:
+    atob "^2.0.0"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -6263,6 +6685,10 @@ source-map-support@^0.5.0:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
   dependencies:
     source-map "^0.6.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map-url@~0.3.0:
   version "0.3.0"
@@ -6329,6 +6755,12 @@ specificity@^0.3.0:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.3.2.tgz#99e6511eceef0f8d9b57924937aac2cb13d13c42"
 
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
+
 split2@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/split2/-/split2-0.2.1.tgz#02ddac9adc03ec0bb78c1282ec079ca6e85ae900"
@@ -6359,6 +6791,13 @@ staggerjs@^1.1.0:
   dependencies:
     tcomb "^3"
     throttle-function "^0.1.0"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
@@ -6629,6 +7068,12 @@ supports-color@^4.0.0, supports-color@^4.2.1, supports-color@^4.4.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
 svg-react-loader@^0.4.4:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/svg-react-loader/-/svg-react-loader-0.4.5.tgz#1f324c9c7b858f5c89fac752bbe9ca3f6214f850"
@@ -6793,6 +7238,27 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.1.tgz#15358bee4a2c83bd76377ba1dc049d0f18837aae"
+  dependencies:
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    regex-not "^1.0.0"
+
 toposort@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
@@ -6838,13 +7304,14 @@ ts-jest@^21.1.2:
     source-map-support "^0.5.0"
     yargs "^9.0.1"
 
-ts-loader@^2.2.2:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.7.tgz#a9028ced473bee12f28a75f9c5b139979d33f2fc"
+ts-loader@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-3.5.0.tgz#151d004dcddb4cf8e381a3bf9d6b74c2d957a9c0"
   dependencies:
-    chalk "^2.0.1"
+    chalk "^2.3.0"
     enhanced-resolve "^3.0.0"
     loader-utils "^1.0.2"
+    micromatch "^3.1.4"
     semver "^5.0.1"
 
 tslib@^1.0.0, tslib@^1.7.1:
@@ -6921,9 +7388,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.4.1, typescript@^2.5.3:
+typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+
+typescript@^2.6.2:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 uglify-js@3.1.x:
   version "3.1.3"
@@ -6957,6 +7428,15 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -6984,6 +7464,13 @@ universalify@^0.1.0:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
 
 unzip-response@^2.0.1:
   version "2.0.1"
@@ -7037,6 +7524,14 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"
+  dependencies:
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    lazy-cache "^2.0.2"
 
 user-home@^1.1.1:
   version "1.1.1"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -348,7 +348,7 @@ axios@^0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-babel-cli@^6.16.0, babel-cli@^6.26.0:
+babel-cli@^6.16.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
   dependencies:

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4666,9 +4666,9 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-metarpheus-io-ts@^0.1.12:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/metarpheus-io-ts/-/metarpheus-io-ts-0.1.13.tgz#4a2ab1378e40530b69e166ac710950e737d14b24"
+metarpheus-io-ts@^0.1.14:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/metarpheus-io-ts/-/metarpheus-io-ts-0.1.14.tgz#699b3a3661a3ef8ddead2a869f4226a295431b27"
   dependencies:
     commander "^2.9.0"
     io-ts-codegen "^0.1.1"
@@ -6333,9 +6333,9 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-scriptoni@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/scriptoni/-/scriptoni-0.10.0.tgz#aa1eb3b5ad075ebf99d4ea952d98df3a3ed2ad82"
+scriptoni@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/scriptoni/-/scriptoni-0.10.1.tgz#6a4a710f641903c0b78e456915b4a6cd34472cf9"
   dependencies:
     babel-cli "^6.16.0"
     babel-core "^6.24.1"
@@ -6356,7 +6356,7 @@ scriptoni@^0.10.0:
     html-webpack-plugin "^2.29.0"
     io-ts "^0.9.2"
     metarpheus "0.1.7"
-    metarpheus-io-ts "^0.1.12"
+    metarpheus-io-ts "^0.1.14"
     metarpheus-tcomb "^0.2"
     minimist "^1.2.0"
     node-glob "^1.2.0"


### PR DESCRIPTION
Closes #29 

* Added `declaration: true` to `compilerOptions` to generate the TS typings during compilation
* Removed `allowJs` since incompatible with `declaration`, and added all `js` files to `exclude`
* `build` command modidied to call babel on the `.js` files after `tsc`: in this way `js` files (ignored by `tsc`) are transpiled and added to the output `lib`

This is breaking for non TS projects using toctoc: 
* it will not be possible to import the `js` model or api directly from `buildo-toctoc`: from now on they must be imported from `buildo-toctoc/api` and `buildo-toctoc/model`

# Tested locally on a TS project

It works:

![](https://i.gyazo.com/8e0df3ccbe2a1fb25fdc7de0c022fcda.gif)


# Tested locally on a JS project

It works after changing imports as follows where needed:

```diff
-import { Model } from 'buildo-toctoc';
+import { Model } from 'buildo-toctoc/lib/model';

-import { API } from 'buildo-toctoc';
+import { API } from 'buildo-toctoc/lib/api';
```

![](https://i.gyazo.com/e77054d571633e6e8ec4a1409b4e5cf2.gif)